### PR TITLE
Update ntag21x_protect.py

### DIFF
--- a/examples/ntag21x_protect.py
+++ b/examples/ntag21x_protect.py
@@ -65,8 +65,8 @@ def loop():
     # nfc.ntag21x_auth(password)
 
     status, buf = nfc.mifareultralight_ReadPage(3)
-    capacity = int(buf[2]) * 8
-    print("Tag capacity {:d} bytes".format(capacity))
+    capacity = int(buf[2])
+    print("Tag capacity {:d} bytes".format(capacity*8))
 
     cfg_page_base = 0x29   # NTAG213
     if (capacity == 0x3E):


### PR DESCRIPTION
If we have a ntag216 e.g. it has a capacity value of 0x6D but if you multiply it with 8 to get the bytes count you can't compare it a few lines below... 
0x6D * 8 = 0x368 != 0x6D

Let me know if I'm on the wrong way