### PR TITLE
Fix for OSError: [Errno 121] Remote I/O error

### DIFF
--- a/pn532pi/interfaces/pn532i2c.py
+++ b/pn532pi/interfaces/pn532i2c.py
@@ -21,6 +21,7 @@ class Pn532I2c(Pn532Interface):
 
     def begin(self):
         self._wire = I2CMaster(self._bus)
+        time.sleep(1)
 
     def wakeup(self):
         time.sleep(.05) # wait for all ready to manipulate pn532


### PR DESCRIPTION
Adding a delay of 1 sec after establishing the i2c bus prevents this error.  Seems you need to allow the i2c bus to establish before sending a command, otherwise you get this error.  Tried reducing the delay time but 1 sec seems to be the right length.  Tested on an RPi3.