### PR TITLE
17 set spi bus speed

### DIFF
--- a/pn532pi/interfaces/pn532spi.py
+++ b/pn532pi/interfaces/pn532spi.py
@@ -45,17 +45,20 @@ class Pn532Spi(Pn532Interface):
         data_out = list(_reverse_bits([STATUS_READ, 0]))
         return _reverse_bits(self._spi.xfer2(data_out))[1]
 
-    def __init__(self, ss: int):
+    def __init__(self, ss: int, speed_hz: int=4_000_000):
+        """Pass in slave select pin and optional speed (4MHz default, 5MHz max)"""
         self._command = 0
         self._ss = ss
         self._spi = SpiDev()
+        assert speed_hz <= 5_000_000, "SPI Bus speed must be <= 5MHz"
+        self._speed = speed_hz
         assert ss in [1, 0], 'Chip select must be 1 or 0'
 
     def begin(self):
         self._spi.open(RPI_BUS0, self._ss)
         self._spi.mode = SPI_MODE0  # PN532 only supports mode0
         self._spi.cshigh = False  # Active low
-        self._spi.max_speed_hz = 5000000 # 5 MHz
+        self._spi.max_speed_hz = self._speed
 
     def wakeup(self) -> None:
         # Chip select controlled by driver

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pn532pi",
-    version="1.5",
+    version="1.6",
     author="gassajor000",
     author_email="lgassjsg@example.com",
     description="PN532 library for Raspberry Pi",

--- a/test/unit/test_pn532spi.py
+++ b/test/unit/test_pn532spi.py
@@ -49,7 +49,7 @@ class TestPn532spi(TestCase):
 
         self.assertEqual(0, MOCK_SPI.mode, "spi mode not set to 0!")
         self.assertEqual(False, MOCK_SPI.cshigh, "spi cshigh not set to False!")
-        self.assertLessEqual(5000000, MOCK_SPI.max_speed_hz, "spi max_speed_hz greater than 5MHz!")
+        self.assertLessEqual(MOCK_SPI.max_speed_hz, 5000000, "spi max_speed_hz greater than 5MHz!")
         MOCK_SPI.open.assert_called_once_with(0, 0)     # SPI Bus 0, SS 0
 
         MOCK_SPI.reset_mock()
@@ -57,6 +57,18 @@ class TestPn532spi(TestCase):
         pn532.begin()
 
         MOCK_SPI.open.assert_called_once_with(0, 1)  # SPI Bus 0, SS 1
+        assert MOCK_SPI.max_speed_hz == 4_000_000
+
+        MOCK_SPI.reset_mock()
+        pn532 = Pn532Spi(ss=Pn532Spi.SS1_GPIO7, speed_hz=int(1e6))
+        pn532.begin()
+
+        assert MOCK_SPI.max_speed_hz == 1_000_000
+
+        MOCK_SPI.reset_mock()
+        with self.assertRaises(AssertionError):
+            pn532 = Pn532Spi(ss=Pn532Spi.SS1_GPIO7, speed_hz=int(10e6))
+
 
     def test_invalidSlaveSelect(self):
         """pn532spi accepts only valid slave select values"""


### PR DESCRIPTION
Allow setting the SPI bus speed in the Interface constructor and lower the default speed to 4 MHz.
Closes #17 