### PR TITLE
Fix #25: [IOERROR] - problem when doing i2c communication on the raspberry pi 5 using the Elechouse NFC Module V3

### DIFF
--- a/pn532pi/interfaces/pn532i2c.py
+++ b/pn532pi/interfaces/pn532i2c.py
@@ -154,6 +154,9 @@ class Pn532I2c(Pn532Interface):
         DMSG(time.time())
         DMSG('\n')
 
+        # Support older Python versions without errno.EREMOTEIO defined
+        EREMOTEIO = getattr(errno, 'EREMOTEIO', 121)
+
         t = 0
         while t <= PN532_ACK_WAIT_TIME:
             try:
@@ -164,10 +167,10 @@ class Pn532I2c(Pn532Interface):
                     break # PN532 is ready
             except IOError as e:
                 # As of Python 3.3 IOError is the same as OSError so we should check the error code
-                if e.errno != errno.EIO:
-                    raise   # Reraise the error   
+                if e.errno != errno.EIO and e.errno != EREMOTEIO:
+                    raise   # Reraise the error
                 # Otherwise do nothing, sleep and try again
-            
+
             time.sleep(.001)    # sleep 1 ms
             t+=1
         else:


### PR DESCRIPTION
The issue was that Raspberry Pi 5 uses the DesignWare I2C chip, which is interfaced through the `i2c-designware` kernel driver which returns `EREMOTEIO` instead of `EIO` for negative acknowledgement (NAK) which happens during the PN532 polling/ready phase. Treating `EREMOTEIO` like `EIO` fixes the communication issue.

---

Analysis of this fix by Claude Opus 4.6:

## The Issue

[gassajor000/pn532pi#25](https://github.com/gassajor000/pn532pi/issues/25) reports `OSError: [Errno 121] Remote I/O error` when using the PN532 NFC module over I2C on a Raspberry Pi 5. Multiple users confirmed the problem, and all noted that libnfc works fine on the same hardware.

## How the PN532 I2C Protocol Works

The PN532 communicates over I2C with a polling protocol: after sending a command, the host repeatedly reads the I2C bus waiting for the chip to signal readiness. When the PN532 isn't ready, it **NAKs** (does not acknowledge) the I2C transaction. This is expected, normal, transient behavior.

In `_readAckFrame()`, the code catches the resulting `IOError` from a NAK, ignores it, sleeps briefly, and retries. The original code only caught `errno.EIO` (errno 5).

## Root Cause: Different I2C Hardware and Driver on RPi 5

The Raspberry Pi 5 uses entirely different I2C hardware than earlier models:

| | RPi 1-4 | RPi 5 |
|---|---|---|
| **I2C hardware** | Broadcom BSC (integrated in SoC) | Synopsys DesignWare IP (in the RP1 southbridge chip, connected via PCIe) |
| **Kernel driver** | `i2c-bcm2835` | `i2c-designware` |
| **Errno for NAK** | `EIO` (5) or `EREMOTEIO` (121) | `EREMOTEIO` (121) |

The **RP1** is a custom Raspberry Pi-designed southbridge chip that handles all GPIO/I2C/SPI on the Pi 5, replacing the integrated peripherals from earlier Broadcom SoCs. The RP1's device tree confirms its I2C controllers use `compatible = "snps,designware-i2c"` ([rp1.dtsi](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts/broadcom/rp1.dtsi)), meaning they are driven by the upstream Linux `i2c-designware` driver rather than the Broadcom-specific `i2c-bcm2835` driver.

### The DesignWare driver returns `EREMOTEIO` for NAK

The kernel function `i2c_dw_handle_tx_abort()` in [`i2c-designware-common.c`](https://github.com/torvalds/linux/blob/master/drivers/i2c/busses/i2c-designware-common.c) (lines 945-965):

```c
int i2c_dw_handle_tx_abort(struct dw_i2c_dev *dev)
{
    unsigned long abort_source = dev->abort_source;

    if (abort_source & DW_IC_TX_ABRT_NOACK) {
        ...
        return -EREMOTEIO;
    }
    ...
    return -EIO;
}
```

`DW_IC_TX_ABRT_NOACK` (address or data NAK) returns `-EREMOTEIO` (121). Only non-NAK failures fall through to `-EIO` (5).

### The BCM2835 driver also returns `EREMOTEIO` on modern kernels

Notably, the upstream `i2c-bcm2835` driver used on RPi 1-4 with modern kernels also distinguishes NAK from other errors ([`i2c-bcm2835.c`](https://github.com/torvalds/linux/blob/master/drivers/i2c/busses/i2c-bcm2835.c)):

```c
if (i2c_dev->msg_err & BCM2835_I2C_S_ERR)
    return -EREMOTEIO;
return -EIO;
```

This means older Pi models running recent kernels may also have been affected.

### The semantic difference

Per the [Linux kernel I2C fault codes documentation](https://docs.kernel.org/i2c/fault-codes.html):

- **`EIO`** (5): "Something went wrong when performing an I/O operation" - a vague, generic error
- **`EREMOTEIO`** (121): "The remote device did not acknowledge" - specifically indicates a NAK

The DesignWare driver is more semantically correct in using `EREMOTEIO` for NAK conditions. The old BCM2708 driver (used on earlier Pi models with older kernels) was less precise, lumping everything into `EIO`.

## References

1. **GitHub issue**: [gassajor000/pn532pi#25](https://github.com/gassajor000/pn532pi/issues/25) - original bug report
2. **RP1 device tree** (confirms DesignWare I2C): [raspberrypi/linux `rp1.dtsi`](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts/broadcom/rp1.dtsi)
3. **DesignWare I2C driver** (returns `EREMOTEIO` for NAK): [torvalds/linux `i2c-designware-common.c`](https://github.com/torvalds/linux/blob/master/drivers/i2c/busses/i2c-designware-common.c)
4. **BCM2835 I2C driver** (also returns `EREMOTEIO` for NAK): [torvalds/linux `i2c-bcm2835.c`](https://github.com/torvalds/linux/blob/master/drivers/i2c/busses/i2c-bcm2835.c)
5. **Linux I2C fault codes**: [kernel.org docs](https://docs.kernel.org/i2c/fault-codes.html)
6. **Raspberry Pi processors documentation** (RP1 as southbridge): [raspberrypi.com](https://www.raspberrypi.com/documentation/computers/processors.html)
7. **Python `errno` module**: [docs.python.org](https://docs.python.org/3/library/errno.html)
